### PR TITLE
Add :file-roll-daily? to options (Fix #4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,21 +13,22 @@ Include `[district.server.logging]` in your CLJS file, where you use `mount/star
 **Warning:** district0x modules are still in early stages, therefore API can change in a future.
 
 ## Real-world example
-To see how district server modules play together in real-world app, you can take a look at [NameBazaar server folder](https://github.com/district0x/name-bazaar/tree/master/src/name_bazaar/server), 
+To see how district server modules play together in real-world app, you can take a look at [NameBazaar server folder](https://github.com/district0x/name-bazaar/tree/master/src/name_bazaar/server),
 where this is deployed in production.
 
 ## Usage
-You can pass following args to logging module: 
+You can pass following args to logging module:
 * `:level` Min. level that should be logged
 * `:console?` Pass true if you want to log into console as well
-* `:file-path` Absolute path to log file
+* `:file` [file](https://sentry.io/) [configuration options](#file)
 * `:sentry` [sentry](https://sentry.io/) [configuration options](#sentry)
+
 
 Log calls take the following arguments:
 
 * `message` (required) string with a human-readable message.
 * `meta` (optional) a map with context meta-data.
-* `ns` (optional) namespaced keyword for easy aggregating and searching. If none provided the module will do it's best to figure out which namespace is the log call coming from. 
+* `ns` (optional) namespaced keyword for easy aggregating and searching. If none provided the module will do it's best to figure out which namespace is the log call coming from.
 
 Example:
 
@@ -43,16 +44,22 @@ Example:
     (mount/start))
 
   (log/error "Some error" {:error "Bad things"} ::error)
-  ;; ERROR Some error 
+  ;; ERROR Some error
   ;; {:error "Bad things"}
   ;;  in :my-district/error[my-district.clj:18] at Tue Oct 23 2018 19:20:20 GMT+0200 (CEST)
 ```
+
+### <a name="file"> file configuration options
+In order to initialize the file logging appender pass a map of options:
+
+* `:path` Absolute path to log file
+* `:roll-daily?` When true, the file at `:path` will rotate daily
 
 ### <a name="sentry"> sentry configuration options
 In order to initialize sentry logging appender pass a map of options:
 
 * `:dsn` (required) tells the SDK where to send the events.
-* `:debug` (optional) set to `true` if you want to turn debug mode on and get some extra information if something goes wrong when sending the event. The default is `false`. 
+* `:debug` (optional) set to `true` if you want to turn debug mode on and get some extra information if something goes wrong when sending the event. The default is `false`.
 * `:maxBreadcrumbs` (optional) controls the total amount of breadcrumbs that should be captured, default is 100.
 * `:min-level` (optional) sets the minimal level of logging to sentry, `:warn` is the default. This setting overrides the timbres `:level` flag!
 
@@ -68,17 +75,17 @@ Example:
 
 In order to get the most of sentry logging facilities the log call should pass inside its meta-data:
 
-* `:error` the vanilla error object 
+* `:error` the vanilla error object
 * `:user` the user meta-data such as `:id`, `:username` `:email` `:ip-address` etc.
 
 Example:
 
 ```clojure
-(log/error "foo" {:error (js/Error. "bad error") 
+(log/error "foo" {:error (js/Error. "bad error")
                   :user {:id "0xd1090C557909E2A91FA534d4F54dA82D47f3788e"
                   :username "Hans"
                   :email "user@district.com"
-                  :ip-address "90.177.15.65"}} 
+                  :ip-address "90.177.15.65"}}
                  ::error)
 ```
 

--- a/project.clj
+++ b/project.clj
@@ -6,9 +6,11 @@
   :dependencies [[district0x/district-server-config "1.0.1"]
                  [district0x/error-handling "1.0.3"]
                  [mount "0.1.11"]
-                 [org.clojure/clojurescript "1.9.946"]
+                 [org.clojure/clojurescript "1.10.520"]
                  [com.taoensso/timbre "4.10.0"]
-                 [com.taoensso/encore "2.92.0"]]
+                 [com.taoensso/encore "2.92.0"]
+                 [district0x/district-format "1.0.8"]
+                 [com.andrewmcveigh/cljs-time "0.5.2"]]
 
   :npm {:dependencies [[chalk "2.3.0"]
                        ["@sentry/node" "4.2.1"]]
@@ -17,9 +19,9 @@
   :figwheel {:server-port 4661}
 
   :profiles {:dev {:dependencies [[org.clojure/clojure "1.8.0"]
-                                  [com.cemerick/piggieback "0.2.2"]
-                                  [figwheel-sidecar "0.5.14"]
-                                  [org.clojure/tools.nrepl "0.2.13"]]
+                                  [cider/piggieback "0.4.0"]
+                                  [figwheel-sidecar "0.5.18"]]
+                   :repl-options {:nrepl-middleware [cider.piggieback/wrap-cljs-repl]}
                    :plugins [[lein-cljsbuild "1.1.7"]
                              [lein-figwheel "0.5.14"]
                              [lein-npm "0.6.2"]

--- a/test/tests/all.cljs
+++ b/test/tests/all.cljs
@@ -4,7 +4,12 @@
    [cljs.nodejs :as nodejs]
    [district.server.logging]
    [mount.core :as mount]
-   [taoensso.timbre :as log]))
+   [taoensso.timbre :as log]
+   [cljs-node-io.file :refer [File]]
+   [cljs-time.core :as t]
+   [district.server.logging :refer [file-appender]]
+   [clojure.string :as str]
+   [cljs-node-io.core :as io :refer [slurp]]))
 
 (def path "/tmp/my-log.log")
 
@@ -12,13 +17,16 @@
   :each
   {:after
    (fn []
+     (let [f (File. path)]
+       (when (.exists f)
+         (.delete f)))
      (mount/stop))})
 
 (deftest test-logging
   (-> (mount/with-args
         {:logging {:level :warn
                    :console? true
-                   :file-path path}})
+                   :file {:path path}}})
       (mount/start))
 
   (let [fs (nodejs/require "fs")
@@ -30,3 +38,61 @@
                                 (-> (cljs.reader/read-string (or err data))
                                     :message
                                     (#(is (= "foo" %))))))))
+
+(deftest file-appender-roll-test-1
+  (testing "It should NOT roll when daily-roll? disabled"
+    (let [now (atom (t/date-time 2019 1 1))]
+      (with-redefs [t/now (fn [] @now)]
+        (-> (mount/with-args
+              {:logging {:level :warn
+                         :file {:path path}}})
+            (mount/start))
+
+        ;; log something
+        (log/error "foo" {:error "bad error" :user {:id "0xd1090C557909E2A91FA534d4F54dA82D47f3788e"}} ::error)
+
+        ;; move to the next day
+        (reset! now (t/date-time 2019 1 2))
+
+        ;; log something else
+        (log/error "bar" {:error "other bad error" :user {:id "0xd1090C557909E2A91FA534d4F54dA82D47f3788e"}} ::error)
+
+        (is (= (-> (slurp path)
+                   (str/split-lines)
+                   count)
+               2)
+            "Since rolling is disable log file should contain 2 lines")))))
+
+(deftest file-appender-roll-test-2
+  (testing "It should roll when daily-roll? enabled"
+    (let [now (atom (t/date-time 2019 1 1))
+          old-file-path (str path "-20190101")]
+      (with-redefs [t/now (fn [] @now)]
+        (-> (mount/with-args
+              {:logging {:level :warn
+                         :file {:path path
+                                :roll-daily? true}}})
+            (mount/start))
+
+        ;; log something
+        (log/error "foo" {:error "bad error" :user {:id "0xd1090C557909E2A91FA534d4F54dA82D47f3788e"}} ::error)
+
+        ;; move to the next day
+        (reset! now (t/date-time 2019 1 2))
+
+        ;; log something else
+        (log/error "bar" {:error "other bad error" :user {:id "0xd1090C557909E2A91FA534d4F54dA82D47f3788e"}} ::error)
+
+        (is (= (-> (slurp path)
+                   (str/split-lines)
+                   count)
+               1)
+            "Since rolling is enabled log file should contain 1 line")
+
+        (is (= (-> (slurp old-file-path)
+                   (str/split-lines)
+                   count)
+               1)
+            "Since rolling is enabled a rolled file should exist and should contain 1 line")
+
+        ))))


### PR DESCRIPTION
A :file-roll-daily? keyword was added to options instead of the nested map to avoid breakage.